### PR TITLE
Changes for 1.2.1-alpha

### DIFF
--- a/_data/sidebars/overview_sidebar.yml
+++ b/_data/sidebars/overview_sidebar.yml
@@ -1,7 +1,7 @@
 entries:
 - title: STU3 | FHIR END OF LIFE |
   product: STU3 | FHIR END OF LIFE |
-  version: 1.2.0-alpha
+  version: 1.2.1-alpha
   levels: one
   folders:
 

--- a/pages/explore/explore_overview.md
+++ b/pages/explore/explore_overview.md
@@ -130,5 +130,3 @@ The previous Atomic Units concept has been moved to the Design & Build section w
 <td><a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-OtherDocuments-QuestionnaireResponse-1">EOL-OtherDocuments-QuestionnaireResponse-1</a></td>
 </tr>
 </table>
-
-<b>*</b>Please note the implementation uses CareConnect-Patient-1 instead of the EOL-Patient-1.

--- a/pages/explore/explore_overview.md
+++ b/pages/explore/explore_overview.md
@@ -39,7 +39,7 @@ The previous Atomic Units concept has been moved to the Design & Build section w
 <td>
 <a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
 <a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-LPA-Flag-1">EOL-LPA-Flag-1</a><br/>
-<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-LPA-RelatedPerson-1">EOL-LPARelatedPerson-1</a></br>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-LPA-RelatedPerson-1">EOL-LPARelatedPerson-1</a>
 </td>
 </tr>
 <tr>
@@ -61,7 +61,7 @@ The previous Atomic Units concept has been moved to the Design & Build section w
 <a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Organization-1">CareConnect-Organization-1</a><br/>
 <a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Practitioner-1">CareConnect-Practitioner-1</a><br/>
 <a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-PractitionerRole-1">CareConnect-PractitionerRole-1</a><br/>
-<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-CPRStatus-Flag-1">EOL-CPRStatus-Flag-1</a></br>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-CPRStatus-Flag-1">EOL-CPRStatus-Flag-1</a><br/>
 <a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-CPRStatus-QuestionnaireResponse-1">EOL-CPRStatus-QuestionnaireResponse-1</a>
 </td>
 </tr>
@@ -81,7 +81,7 @@ The previous Atomic Units concept has been moved to the Design & Build section w
 <a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Organization-1">CareConnect-Organization-1</a><br/>
 <a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Practitioner-1">CareConnect-Practitioner-1</a><br/>
 <a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-PractitionerRole-1">CareConnect-PractitionerRole-1</a><br/>
-<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Prognosis-ClinicalImpression-1">EOL-Prognosis-ClinicalImpression-1</a></br>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Prognosis-ClinicalImpression-1">EOL-Prognosis-ClinicalImpression-1</a>
 </td>
 </tr>
 <tr>

--- a/pages/explore/explore_overview.md
+++ b/pages/explore/explore_overview.md
@@ -24,16 +24,6 @@ The previous Atomic Units concept has been moved to the Design & Build section w
 <th style="width:33%;">FHIR Profile(s)</th>
 </tr>
 <tr>
-<td>Communication</td>
-<td>Patient</td>
-<td><a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Patient-1"><b>*</b>CareConnect-Patient-1</a></td>
-</tr>
-<tr>
-<td>Contacts</td>
-<td>Patient</td>
-<td><a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Patient-1"><b>*</b>CareConnect-Patient-1</a></td>
-</tr>
-<tr>
 <td><a href="api_eol_lastingpowerofattorney.html">Lasting Power of Attorney (LPA)</a></td>
 <td>Patient<br/>Flag<br/>Related Person</td>
 <td>

--- a/pages/explore/explore_overview.md
+++ b/pages/explore/explore_overview.md
@@ -11,7 +11,7 @@ summary: "Overview of the Resources section"
 
 ## 1. End of Life Recording ##
 
-This page provides an overview of the FHIR STU3 Resources that are required to build the required API messaging. Each link will take you to the resource page detail with a link to the Structure Definitions of each resource.
+This page provides an overview of the FHIR STU3 Resources that are required to build the required API messaging.
 
 The previous Atomic Units concept has been moved to the Design & Build section where the API is defined.
 
@@ -26,77 +26,119 @@ The previous Atomic Units concept has been moved to the Design & Build section w
 <tr>
 <td>Communication</td>
 <td>Patient</td>
-<td><a href="api_eol_entity_patient.html">CareConnect-Patient-1</a></td>
+<td><a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Patient-1">CareConnect-Patient-1</a><b>*</b></td>
 </tr>
 <tr>
 <td>Contacts</td>
 <td>Patient</td>
-<td><a href="api_eol_entity_patient.html">CareConnect-Patient-1</a></td>
+<td><a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Patient-1">CareConnect-Patient-1</a><b>*</b></td>
 </tr>
 <tr>
-<td>LPA Lasting Power of Attorney</td>
-<td>Related Person</td>
-<td><a href="api_eol_entity_lpa_relatedperson.html">EOL-LPARelatedPerson-1</a></td>
+<td><a href="api_eol_lastingpowerofattorney.html">Lasting Power of Attorney (LPA)</a></td>
+<td>Patient<br/>Flag<br/>Related Person</td>
+<td>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-LPA-Flag-1">EOL-LPA-Flag-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-LPA-RelatedPerson-1">EOL-LPARelatedPerson-1</a></br>
+</td>
 </tr>
 <tr>
-<td>Consent</td>
-<td>Consent<br/>Practitioner<br/>Practitioner Role</td>
-<td><a href="api_eol_security_consent.html">EOL-Consent-1</a><br/>
- <a href="api_eol_individuals_practitioner.html">CareConnect-Practitioner-1</a><br/>
- <a href="api_eol_individuals_practitionerrole.html">CareConnect-PractitionerRole-1 </a></td>
+<td><a href="api_eol_consent.html">Consent</a></td>
+<td>Patient<br/>Organization<br/>Practitioner<br/>PractitionerRole<br/>Consent<br/></td>
+<td>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Organization-1">CareConnect-Organization-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Practitioner-1">CareConnect-Practitioner-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-PractitionerRole-1">CareConnect-PractitionerRole-1 </a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Consent-1">EOL-Consent-1</a>
+</td>
 </tr>
 <tr>
-<td>CPR Status</td>
-<td>Flag<br/>Encounter<br/>Observation</td>
-<td><a href="api_eol_management_flag_cprstatus.html">EOL-CPRStatus-Flag-1</a><br/>
-<a href="api_eol_management_encounter_cprstatus.html">EOL-CPRStatus-Encounter-1</a><br/>
-<a href="api_eol_diagnostics_observation_cprstatus.html">EOL-CPRStatus-Observation-1</a></td>
+<td><a href="api_eol_cprstatus.html">CPR Status</a></td>
+<td>Patient<br/>Organization<br/>Practitioner<br/>PractitionerRole<br/>Flag<br/>QuestionnaireResponse<br/></td>
+<td>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Organization-1">CareConnect-Organization-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Practitioner-1">CareConnect-Practitioner-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-PractitionerRole-1">CareConnect-PractitionerRole-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-CPRStatus-Flag-1">EOL-CPRStatus-Flag-1</a></br>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-CPRStatus-QuestionnaireResponse-1">EOL-CPRStatus-QuestionnaireResponse-1</a>
+</td>
 </tr>
 <tr>
-<td>End of Life Register</td>
-<td>Flag</td>
-<td><a href="api_eol_management_flag_register.html">EOL-Register-Flag-1</a></td>
+<td><a href="api_eol_register.html">End of Life Register</a></td>
+<td>Patient<br/>Flag</td>
+<td>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Register-Flag-1">EOL-Register-Flag-1</a>
+</td>
 </tr>
 <tr>
-<td>Prognosis</td>
-<td>Encounter<br/>Observation</td>
-<td><a href="api_eol_management_encounter_prognosis.html">EOL-Prognosis-Encounter-1</a><br/>
-<a href="api_eol_diagnostics_observation_prognosis.html">EOL-Prognosis-Observation-1</a></td>
+<td><a href="api_eol_prognosis.html">Prognosis</a></td>
+<td>Patient<br/>Organization<br/>Practitioner<br/>PractitionerRole<br/>ClinicalImpression</td>
+<td>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Organization-1">CareConnect-Organization-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Practitioner-1">CareConnect-Practitioner-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-PractitionerRole-1">CareConnect-PractitionerRole-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Prognosis-ClinicalImpression-1">EOL-Prognosis-ClinicalImpression-1</a></br>
+</td>
 </tr>
 <tr>
-<td>Advance Treatment Preferences</td>
-<td>Condition<br/>List<br/>CarePlan<br/>Questionnaire Response<br/>Practitioner<br/>Practioner Role</td>
-<td><a href="api_eol_management_problemlist.html">CareConnect-ProblemList-1</a><br/>
- <a href="api_eol_summary_problemheader_condition.html">CareConnect-ProblemHeader-Condition-1</a><br/>
- <a href="api_eol_summary_atp_careplan.html">EOL-AdvanceTreatmentPreferences-CarePlan-1</a><br/>
- <a href="api_eol_advancetreatmentpreferences_questionnaireresponse.html">EOL-AdvanceTreatmentPreferences-QuestionnaireResponse-1</a><br/>
- <a href="api_eol_individuals_practitioner.html">CareConnect-Practitioner-1</a><br/>
- <a href="api_eol_individuals_practitionerrole.html">CareConnect-PractitionerRole-1</a></td>
-
+<td><a href="api_eol_atp.html">Advance Treatment Preferences</a></td>
+<td>Patient<br/>Organization<br/>Practitioner<br/>PractitionerRole<br/>Location</br>Procedure</br>List</br>Condition</br>CarePlan</br>Flag</td>
+<td>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Organization-1">CareConnect-Organization-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Practitioner-1">CareConnect-Practitioner-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-PractitionerRole-1">CareConnect-PractitionerRole-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Location-1">CareConnect-Location-1</a></br>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-EOL-Procedure-1">CareConnect-EOL-Procedure-1</a></br>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ATPProblemList-List-1">EOL-ATPProblemList-List-1</a></br>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ATPProblemHeader-Condition-1">EOL-ATPProblemHeader-Condition-1</a></br>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ATP-CarePlan-1">EOL-ATP-CarePlan-1</a></br>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ADRT-Flag-1">EOL-ADRT-Flag-1</a></br>
+</td>
 </tr>
 <tr>
-<td>Disability</td>
-<td>Condition (Problem)<br/>List<br/>Practitioner<br/>Practioner Role</td>
-<td><a href="api_eol_summary_disability_condition.html">CareConnect-ProblemHeader-Condition-1</a><br/>
-<a href="api_eol_summary_disability_list.html">CareConnect-ProblemList-1</a><br/>
-<a href="api_eol_individuals_practitioner.html">CareConnect-Practitioner-1</a><br/>
-<a href="api_eol_individuals_practitionerrole.html">CareConnect-PractitionerRole-1</a></td>
+<td><a href="api_eol_disabilities.html">Disabilities</a></td>
+<td>Patient<br/>List<br/>Condition<br/>Practitioner<br/>PractitionerRole<br/>Organization<br/></td>
+<td>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-ProblemList-1">CareConnect-ProblemList-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-ProblemHeader-Condition-1">CareConnect-ProblemHeader-Condition-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Practitioner-1">CareConnect-Practitioner-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-PractitionerRole-1">CareConnect-PractitionerRole-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Organization-1">CareConnect-Organization-1</a>
+</td>
 </tr>
 <tr>
-<td>Functional Status</td>
-<td>Questionnaire Response<br/>Practitioner<br/>Practioner Role</td>
-<td><a href="api_eol_functionalstatus_questionnaireresponse.html">EOL-FunctionalStatus-QuestionnaireResponse-1</a><br/>
-<a href="api_eol_individuals_practitioner.html">CareConnect-Practitioner-1</a><br/>
-<a href="api_eol_individuals_practitionerrole.html">CareConnect-PractitionerRole-1</a></td>
+<td><a href="api_eol_functionalstatus.html">Functional Status</a></td>
+<td>Patient<br/>Organization<br/>Practitioner<br/>PractitionerRole<br/>Observation</td>
+<td>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Organization-1">CareConnect-Organization-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Practitioner-1">CareConnect-Practitioner-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-PractitionerRole-1">CareConnect-PractitionerRole-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-EOL-FunctionalStatus-Observation-1">CareConnect-EOL-FunctionalStatus-Observation-1</a>
+</td>
 </tr>
 <tr>
-<td>Preferences</td>
-<td>Questionnaire Response</td>
-<td><a href="api_eol_preferences_questionnaireresponse.html">EOL-Preferences-QuestionnaireResponse-1</a></td>
+<td><a href="api_eol_preferences.html">Preferences</a></td>
+<td>Patient<br/>Organization<br/>Practitioner<br/>PractitionerRole<br/>QuestionnaireResponse</td>
+<td>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Organization-1">CareConnect-Organization-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Practitioner-1">CareConnect-Practitioner-1</a><br/>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-PractitionerRole-1">CareConnect-PractitionerRole-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Preferences-QuestionnaireResponse-1">EOL-Preferences-QuestionnaireResponse-1</a>
+</td>
 </tr>
 <tr>
-<td>Other Docs</td>
-<td>Document Reference</td>
-<td><a href="api_eol_documents_documentreference.html">EOL Document Reference</a></td>
+<td><a href="api_eol_otherdocuments.html">Other Documents</a></td>
+<td>QuestionnaireResponse</td>
+<td><a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-OtherDocuments-QuestionnaireResponse-1">EOL-OtherDocuments-QuestionnaireResponse-1</a></td>
 </tr>
 </table>
+
+<b>*</b>Please note the implementation uses CareConnect-Patient-1 instead of the EOL-Patient-1.

--- a/pages/explore/explore_overview.md
+++ b/pages/explore/explore_overview.md
@@ -26,12 +26,12 @@ The previous Atomic Units concept has been moved to the Design & Build section w
 <tr>
 <td>Communication</td>
 <td>Patient</td>
-<td><a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Patient-1">CareConnect-Patient-1</a><b>*</b></td>
+<td><a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Patient-1"><b>*</b>CareConnect-Patient-1</a></td>
 </tr>
 <tr>
 <td>Contacts</td>
 <td>Patient</td>
-<td><a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Patient-1">CareConnect-Patient-1</a><b>*</b></td>
+<td><a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Patient-1"><b>*</b>CareConnect-Patient-1</a></td>
 </tr>
 <tr>
 <td><a href="api_eol_lastingpowerofattorney.html">Lasting Power of Attorney (LPA)</a></td>
@@ -86,18 +86,18 @@ The previous Atomic Units concept has been moved to the Design & Build section w
 </tr>
 <tr>
 <td><a href="api_eol_atp.html">Advance Treatment Preferences</a></td>
-<td>Patient<br/>Organization<br/>Practitioner<br/>PractitionerRole<br/>Location</br>Procedure</br>List</br>Condition</br>CarePlan</br>Flag</td>
+<td>Patient<br/>Organization<br/>Practitioner<br/>PractitionerRole<br/>Location<br/>Procedure<br/>List<br/>Condition<br/>CarePlan<br/>Flag</td>
 <td>
 <a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-Patient-1">EOL-Patient-1</a><br/>
 <a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Organization-1">CareConnect-Organization-1</a><br/>
 <a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Practitioner-1">CareConnect-Practitioner-1</a><br/>
 <a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-PractitionerRole-1">CareConnect-PractitionerRole-1</a><br/>
-<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Location-1">CareConnect-Location-1</a></br>
-<a href="https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-EOL-Procedure-1">CareConnect-EOL-Procedure-1</a></br>
-<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ATPProblemList-List-1">EOL-ATPProblemList-List-1</a></br>
-<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ATPProblemHeader-Condition-1">EOL-ATPProblemHeader-Condition-1</a></br>
-<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ATP-CarePlan-1">EOL-ATP-CarePlan-1</a></br>
-<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ADRT-Flag-1">EOL-ADRT-Flag-1</a></br>
+<a href="https://fhir.hl7.org.uk/STU3/StructureDefinition/CareConnect-Location-1">CareConnect-Location-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-EOL-Procedure-1">CareConnect-EOL-Procedure-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ATPProblemList-List-1">EOL-ATPProblemList-List-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ATPProblemHeader-Condition-1">EOL-ATPProblemHeader-Condition-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ATP-CarePlan-1">EOL-ATP-CarePlan-1</a><br/>
+<a href="https://fhir.nhs.uk/STU3/StructureDefinition/EOL-ADRT-Flag-1">EOL-ADRT-Flag-1</a><br/>
 </td>
 </tr>
 <tr>

--- a/pages/overview/overview_release_notes.md
+++ b/pages/overview/overview_release_notes.md
@@ -10,6 +10,11 @@ summary: Summary release notes of the versions released in End of Life API Imple
 {% include important.html content="This site is under active development by NHS Digital and is intended to provide all the technical resources you need to successfully develop the End of Life API. This project is being developed using an agile methodology so iterative updates to content will be added on a regular basis." %}
 
 
+## 1.2.1-alpha ##
+
+- The End of Life Care API’s table in the Resources Overview page, has been altered, to now include links to the Atomic Units and corrections to the FHIR profile links.
+
+
 ## 1.2.0-alpha ##
 
 - Atomic Units navigation section name changed to 'Resources' and API Guidance sub-section removed.


### PR DESCRIPTION
The End of Life Care API’s table in the Resources Overview page, has been altered, to now include links to the Atomic Units and corrections to the FHIR profile links.